### PR TITLE
[Bug Reproduction] Enable workflow on fork to reproduce forEach async bug

### DIFF
--- a/.github/workflows/pr-gh-project-processor.yaml
+++ b/.github/workflows/pr-gh-project-processor.yaml
@@ -14,7 +14,6 @@ jobs:
       pull-requests: write
       repository-projects: write
       id-token: write
-    if: ${{ github.repository_owner == 'rancher' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -22,18 +21,6 @@ jobs:
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
       with:
         node-version-file: '.nvmrc'
-    - name: Read secrets
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
-      with:
-        secrets: |
-          secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;
-          secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | APP_PEM
-    - name: Generate Token
-      id: generate-token
-      uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
-      with:
-        app-id: ${{ env.APP_ID }}
-        private-key: ${{ env.APP_PEM }}
     - name: Download artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
@@ -43,7 +30,7 @@ jobs:
         github-token: ${{ github.token }}
     - name: script
       env:
-        GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PR_PROJECT: ${{ secrets.PR_PROJECT }}
         GITHUB_EVENT_PATH: pr-gh-project-event/event.json
       run: node .github/workflows/scripts/pr-gh-project.js


### PR DESCRIPTION
Fixes #88

This PR enables the pr-gh-project workflow on this fork **without** fixing the forEach async bug.

When this PR is merged, the workflow should run but the forEach async bug means:
- Issue #88 will likely stay **closed** (not re-opened)
- Issue #88 will stay in **Done** on the project board (not moved to 'To Test')

This demonstrates the bug described in rancher/dashboard issue 15714.