### PR TITLE
[Release][2.15] Step 1 - Cut release-2.15 & freeze all branches

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -3,7 +3,7 @@
     "master": {
       "milestone": {
         "version": "v2.15.0",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -29,10 +29,28 @@
         "ui-index": "https://releases.rancher.com/ui/latest2/index.html"
       }
     },
+    "release-2.15": {
+      "milestone": {
+        "version": "v2.15.0",
+        "codeFreeze": true
+      },
+      "e2e": {
+        "rancher-image": {
+          "namespace": "rancher",
+          "name": "rancher",
+          "tag": "v2.15-head"
+        }
+      },
+      "rancher-rancher-repo": {
+        "branch": "release/v2.15",
+        "ui-dashboard-index": "https://releases.rancher.com/dashboard/release-2.15/index.html",
+        "ui-index": "https://releases.rancher.com/ui/release-2.15/index.html"
+      }
+    },
     "release-2.14": {
       "milestone": {
         "version": "v2.14.4",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -50,7 +68,7 @@
     "release-2.13": {
       "milestone": {
         "version": "v2.13.8",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -69,7 +87,7 @@
     "release-2.12": {
       "milestone": {
         "version": "v2.12.12",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -88,7 +106,7 @@
     "release-2.11": {
       "milestone": {
         "version": "v2.11.16",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {


### PR DESCRIPTION
<!-- This template is for Devs to give QA details before moving the issue To-Test -->
### Summary
Fixes #
Release-branching procedure for the 2.15 line (part 1). Adds the `release-2.15` entry to `branches-metadata.json` and puts every branch under code freeze.

> Note: this is a **fork-to-fork** PR (`marcelofukumoto/dashboard` `branching-procedure/v2.15` → `master`) used to replicate/preview the full flow. It is **not** the PR against `rancher/dashboard`.

### Occurred changes and/or fixed issues
branching procedure for 2.15 - part 1:
- Added a new `release-2.15` block (`version: v2.15.0`, `codeFreeze: true`, `tag: v2.15-head`, `branch: release/v2.15`, release-2.15 index URLs).
- Put **every** branch under code freeze — `codeFreeze: true` on `master`, `release-2.15`, `release-2.14`, `release-2.13`, `release-2.12`, `release-2.11`.
- No `milestone.version` values were changed (advancing master to the next minor is a separate later step).

### Technical notes summary
Metadata-only change to `branches-metadata.json`. JSON validated with `jq`. Master's `e2e.helm.repo-url` was intentionally left untouched.

### Areas or cases that should be tested
No code changes — nothing to test at runtime. Verify the `branches-metadata.json` diff matches the branching-procedure shape (new release block + all `codeFreeze` flags flipped).

### Areas which could experience regressions
None — the file is consumed by CI/release tooling only; no application code is affected.

### Screenshot/Video
N/A

### Checklist
- [x] The PR is linked to an issue and the linked issue has a Milestone, or no issue is needed
- [x] The PR has a Milestone
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [ ] The PR has a reviewer assigned
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
- [x] The PR has reviewed with UX and tested in light and dark mode, or there are no UX changes
- [x] The PR has been reviewed in terms of Accessibility
- [x] The PR has considered, and if applicable tested with, the three Global Roles `Admin`, `Standard User` and `User Base`
