### PR TITLE
[Release][2.15] Step 1 - Cut release-2.15 & freeze all branches

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -3,7 +3,7 @@
     "master": {
       "milestone": {
         "version": "v2.15.0",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -29,10 +29,28 @@
         "ui-index": "https://releases.rancher.com/ui/latest2/index.html"
       }
     },
+    "release-2.15": {
+      "milestone": {
+        "version": "v2.15.0",
+        "codeFreeze": true
+      },
+      "e2e": {
+        "rancher-image": {
+          "namespace": "rancher",
+          "name": "rancher",
+          "tag": "v2.15-head"
+        }
+      },
+      "rancher-rancher-repo": {
+        "branch": "release/v2.15",
+        "ui-dashboard-index": "https://releases.rancher.com/dashboard/release-2.15/index.html",
+        "ui-index": "https://releases.rancher.com/ui/release-2.15/index.html"
+      }
+    },
     "release-2.14": {
       "milestone": {
         "version": "v2.14.4",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -50,7 +68,7 @@
     "release-2.13": {
       "milestone": {
         "version": "v2.13.8",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -69,7 +87,7 @@
     "release-2.12": {
       "milestone": {
         "version": "v2.12.12",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -88,7 +106,7 @@
     "release-2.11": {
       "milestone": {
         "version": "v2.11.16",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {

--- a/shell/config/version.js
+++ b/shell/config/version.js
@@ -30,4 +30,4 @@ export function setKubeVersionData(v) {
   _kubeVersionData = JSON.parse(JSON.stringify(v));
 }
 
-export const CURRENT_RANCHER_VERSION = '2.13';
+export const CURRENT_RANCHER_VERSION = '2.15';


### PR DESCRIPTION
### Summary
Fixes #

Step 1 of the release-branching procedure: cut `release-2.15` and put every branch under code freeze.

### Occurred changes and/or fixed issues
branching procedure for 2.15 - part 1:
- Added a new `release-2.15` block to `branches-metadata.json` (copied from the newest release block, `codeFreeze: true`).
- Put **every** branch under code freeze — `master` and all existing release lines (`release-2.14`, `release-2.13`, `release-2.12`, `release-2.11`) — by flipping `milestone.codeFreeze` to `true`. No `milestone.version` values changed.
- Bumped the docs version constant `CURRENT_RANCHER_VERSION` to `'2.15'` in `shell/config/version.js`.

Builds pending.

### Technical notes summary
Metadata-only change. Master keeps its `v2.15.0` milestone; advancing master to the next minor and creating the actual `release-2.15` git branch is Step 2, run after this PR merges.

### Areas or cases that should be tested
No functional/UI changes — metadata + docs version constant only.

### Checklist
- [x] The PR template has been filled out
- [x] The PR has been self reviewed
- [x] The PR has automated tests or clear instructions for manual tests and the linked issue has appropriate QA labels, or tests are not needed
