### PR TITLE
[Release][2.15] Step 2 - Create release-2.15 branch & reopen master for v2.16

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -2,8 +2,8 @@
   "branches": {
     "master": {
       "milestone": {
-        "version": "v2.15.0",
-        "codeFreeze": true
+        "version": "v2.16.0",
+        "codeFreeze": false
       },
       "e2e": {
         "rancher-image": {


### PR DESCRIPTION
## Step 2 — Create release-2.15 branch & reopen master

Second step of the two-step release-branching procedure (Step 1 merged in 368).

- Created the `release-2.15` git branch off the frozen `master`.
- Reopened `master`: `milestone.codeFreeze: false`, `milestone.version: v2.16.0`.
- All `release-*` blocks left frozen and untouched; `master.e2e.helm.repo-url` unchanged.

> TEMPORARY: fork-only test run on marcelofukumoto/dashboard.