### PR TITLE
[Release][2.15] Step 1 - Cut release-2.15 & freeze all branches

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -3,7 +3,7 @@
     "master": {
       "milestone": {
         "version": "v2.15.0",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -29,10 +29,28 @@
         "ui-index": "https://releases.rancher.com/ui/latest2/index.html"
       }
     },
+    "release-2.15": {
+      "milestone": {
+        "version": "v2.15.0",
+        "codeFreeze": true
+      },
+      "e2e": {
+        "rancher-image": {
+          "namespace": "rancher",
+          "name": "rancher",
+          "tag": "v2.15-head"
+        }
+      },
+      "rancher-rancher-repo": {
+        "branch": "release/v2.15",
+        "ui-dashboard-index": "https://releases.rancher.com/dashboard/release-2.15/index.html",
+        "ui-index": "https://releases.rancher.com/ui/release-2.15/index.html"
+      }
+    },
     "release-2.14": {
       "milestone": {
         "version": "v2.14.4",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -50,7 +68,7 @@
     "release-2.13": {
       "milestone": {
         "version": "v2.13.8",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -69,7 +87,7 @@
     "release-2.12": {
       "milestone": {
         "version": "v2.12.12",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -88,7 +106,7 @@
     "release-2.11": {
       "milestone": {
         "version": "v2.11.16",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {

--- a/shell/config/version.js
+++ b/shell/config/version.js
@@ -30,4 +30,4 @@ export function setKubeVersionData(v) {
   _kubeVersionData = JSON.parse(JSON.stringify(v));
 }
 
-export const CURRENT_RANCHER_VERSION = '2.13';
+export const CURRENT_RANCHER_VERSION = '2.15';


### PR DESCRIPTION
## Summary
Branching procedure for 2.15 — part 1.

- Added a new `release-2.15` block to `branches-metadata.json` (copied from `release-2.14`, versions substituted, `codeFreeze: true`).
- Put **every** branch under code freeze — `master` and all existing `release-*` lines (`codeFreeze: true`).
- Bumped `CURRENT_RANCHER_VERSION` to `'2.15'` in `shell/config/version.js`.

No `milestone.version` values were changed. Metadata-only change; no tests needed.

> Fork-to-fork test PR (temporary testing guardrail — fork only).