### PR TITLE
[Release][2.15] Step 1 - Cut release-2.15 & freeze all branches

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -3,7 +3,7 @@
     "master": {
       "milestone": {
         "version": "v2.15.0",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -29,10 +29,28 @@
         "ui-index": "https://releases.rancher.com/ui/latest2/index.html"
       }
     },
+    "release-2.15": {
+      "milestone": {
+        "version": "v2.15.0",
+        "codeFreeze": true
+      },
+      "e2e": {
+        "rancher-image": {
+          "namespace": "rancher",
+          "name": "rancher",
+          "tag": "v2.15-head"
+        }
+      },
+      "rancher-rancher-repo": {
+        "branch": "release/v2.15",
+        "ui-dashboard-index": "https://releases.rancher.com/dashboard/release-2.15/index.html",
+        "ui-index": "https://releases.rancher.com/ui/release-2.15/index.html"
+      }
+    },
     "release-2.14": {
       "milestone": {
         "version": "v2.14.4",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -50,7 +68,7 @@
     "release-2.13": {
       "milestone": {
         "version": "v2.13.8",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -69,7 +87,7 @@
     "release-2.12": {
       "milestone": {
         "version": "v2.12.12",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {
@@ -88,7 +106,7 @@
     "release-2.11": {
       "milestone": {
         "version": "v2.11.16",
-        "codeFreeze": false
+        "codeFreeze": true
       },
       "e2e": {
         "rancher-image": {


### PR DESCRIPTION
## Summary

branching procedure for 2.15 - part 1 — add `release-2.15` block to `branches-metadata.json` and put **every** branch (master + all existing release lines) under **code freeze**.

## Occurred changes

- New `release-2.15` block added immediately after `master` (copied from `release-2.14` shape, versions substituted, `codeFreeze: true`).
- Code freeze enabled on `master`, `release-2.15`, `release-2.14`, `release-2.13`, `release-2.12`, `release-2.11`.
- No `milestone.version` changed; only `branches-metadata.json` touched.

Builds pending.

> Fork-to-fork testing PR (guardrail active).

## Checklist

- [x] PR template filled
- [x] Self-reviewed
- [x] No tests needed (metadata-only change)