### PR TITLE
[Release][2.15] Step 2 - Create release-2.15 branch & reopen master for v2.16

### DIFF
--- a/branches-metadata.json
+++ b/branches-metadata.json
@@ -2,8 +2,8 @@
   "branches": {
     "master": {
       "milestone": {
-        "version": "v2.15.0",
-        "codeFreeze": true
+        "version": "v2.16.0",
+        "codeFreeze": false
       },
       "e2e": {
         "rancher-image": {


### PR DESCRIPTION
## Summary

Step 2 of the release-branching procedure for 2.15 (Step 1 was merged in 375).

- Created the `release-2.15` branch off the frozen `master`.
- Reopened `master`: `milestone.codeFreeze` `true` → `false`, `milestone.version` `v2.15.0` → `v2.16.0`.

All `release-*` blocks remain frozen and untouched, and `master.e2e.helm.repo-url` is unchanged.

## Occurred changes / expected changes

Only `branches-metadata.json` changes, in the `master` block's `milestone` only.

## Areas or cases that should be tested

`branches-metadata.json` parses as valid JSON; `master` is unfrozen at `v2.16.0`; `release-2.15` block still frozen at `v2.15.0`.

## Checklist

- [x] The PR title contains the relevant milestone
- [x] The PR is linked to the relevant issue, if applicable