### PR TITLE
[Release][2.15] Step 4 - Bump docs version to 2.15 (master)

### DIFF
--- a/shell/config/version.js
+++ b/shell/config/version.js
@@ -30,4 +30,4 @@ export function setKubeVersionData(v) {
   _kubeVersionData = JSON.parse(JSON.stringify(v));
 }
 
-export const CURRENT_RANCHER_VERSION = '2.13';
+export const CURRENT_RANCHER_VERSION = '2.15';


### PR DESCRIPTION
### Release 2.15 — Step 4: bump docs version

Sets `shell/config/version.js` `CURRENT_RANCHER_VERSION` from `2.13` to `2.15`.

Reference: rancher/dashboard#17668

Opened automatically by the release console (Step 4 · release, which also updates master).
