### PR TITLE
Guard Masthead against undefined props during render race

### DIFF
--- a/shell/components/Resource/Detail/Masthead/__tests__/index.test.ts
+++ b/shell/components/Resource/Detail/Masthead/__tests__/index.test.ts
@@ -1,5 +1,7 @@
 import { mount } from '@vue/test-utils';
 import Masthead from '@shell/components/Resource/Detail/Masthead/index.vue';
+import TitleBar from '@shell/components/Resource/Detail/TitleBar/index.vue';
+import Metadata from '@shell/components/Resource/Detail/Metadata/index.vue';
 import Cards from '@shell/components/Resource/Detail/Cards.vue';
 
 jest.mock('@shell/utils/clipboard', () => ({ copyTextToClipboard: jest.fn() }));
@@ -19,16 +21,18 @@ describe('component: Masthead/index', () => {
     metadataProps: { items: [] }
   };
 
+  const globalStubs = {
+    stubs: {
+      TitleBar: true,
+      Metadata: true,
+      Cards:    true
+    }
+  };
+
   it('should render the Cards component', () => {
     const wrapper = mount(Masthead, {
       props:  defaultProps,
-      global: {
-        stubs: {
-          TitleBar: true,
-          Metadata: true,
-          Cards:    true
-        }
-      }
+      global: globalStubs
     });
 
     expect(wrapper.findComponent(Cards).exists()).toBe(true);
@@ -37,17 +41,67 @@ describe('component: Masthead/index', () => {
   it('should pass the resource from titleBarProps to Cards', () => {
     const wrapper = mount(Masthead, {
       props:  defaultProps,
-      global: {
-        stubs: {
-          TitleBar: true,
-          Metadata: true,
-          Cards:    true
-        }
-      }
+      global: globalStubs
     });
 
     const cardsComponent = wrapper.findComponent(Cards);
 
     expect(cardsComponent.props('resource')).toStrictEqual(mockResource);
+  });
+
+  it('should render TitleBar when titleBarProps is provided', () => {
+    const wrapper = mount(Masthead, {
+      props:  defaultProps,
+      global: globalStubs
+    });
+
+    expect(wrapper.findComponent(TitleBar).exists()).toBe(true);
+  });
+
+  it('should render Metadata when metadataProps is provided', () => {
+    const wrapper = mount(Masthead, {
+      props:  defaultProps,
+      global: globalStubs
+    });
+
+    expect(wrapper.findComponent(Metadata).exists()).toBe(true);
+  });
+
+  it('should not render TitleBar when titleBarProps is undefined', () => {
+    const wrapper = mount(Masthead, {
+      props:  { titleBarProps: undefined, metadataProps: { items: [] } },
+      global: globalStubs
+    });
+
+    expect(wrapper.findComponent(TitleBar).exists()).toBe(false);
+  });
+
+  it('should not render Metadata when metadataProps is undefined', () => {
+    const wrapper = mount(Masthead, {
+      props:  { titleBarProps: defaultProps.titleBarProps, metadataProps: undefined },
+      global: globalStubs
+    });
+
+    expect(wrapper.findComponent(Metadata).exists()).toBe(false);
+  });
+
+  it('should not render Cards when titleBarProps is undefined', () => {
+    const wrapper = mount(Masthead, {
+      props:  { titleBarProps: undefined, metadataProps: undefined },
+      global: globalStubs
+    });
+
+    expect(wrapper.findComponent(Cards).exists()).toBe(false);
+  });
+
+  it('should not render any children when both props are undefined', () => {
+    const wrapper = mount(Masthead, {
+      props:  { titleBarProps: undefined, metadataProps: undefined },
+      global: globalStubs
+    });
+
+    expect(wrapper.findComponent(TitleBar).exists()).toBe(false);
+    expect(wrapper.findComponent(Metadata).exists()).toBe(false);
+    expect(wrapper.findComponent(Cards).exists()).toBe(false);
   });
 });

--- a/shell/components/Resource/Detail/Masthead/index.vue
+++ b/shell/components/Resource/Detail/Masthead/index.vue
@@ -4,8 +4,8 @@ import Metadata, { MetadataProps } from '@shell/components/Resource/Detail/Metad
 import Cards from '@shell/components/Resource/Detail/Cards.vue';
 
 export interface MastheadProps {
-  titleBarProps: TitleBarProps;
-  metadataProps: MetadataProps;
+  titleBarProps?: TitleBarProps;
+  metadataProps?: MetadataProps;
 }
 </script>
 
@@ -15,7 +15,10 @@ const props = defineProps<MastheadProps>();
 </script>
 <template>
   <div class="masthead">
-    <TitleBar v-bind="props.titleBarProps">
+    <TitleBar
+      v-if="props.titleBarProps"
+      v-bind="props.titleBarProps"
+    >
       <template
         v-if="$slots['additional-actions']"
         #additional-actions
@@ -24,10 +27,12 @@ const props = defineProps<MastheadProps>();
       </template>
     </TitleBar>
     <Metadata
+      v-if="props.metadataProps"
       class="metadata-section"
       v-bind="props.metadataProps"
     />
     <Cards
+      v-if="props.titleBarProps"
       class="cards-section"
       :resource="props.titleBarProps.resource"
     />

--- a/shell/models/management.cattle.io.cluster.js
+++ b/shell/models/management.cattle.io.cluster.js
@@ -180,7 +180,7 @@ export default class MgmtCluster extends SteveModel {
   }
 
   get machineProvider() {
-    return this.status?.info.machineProvider;
+    return this.status?.info?.machineProvider;
   }
 
   get machineProviderDisplay() {


### PR DESCRIPTION
Replicated PR for QA-workflow testing (base `master-test`).

Fixes #389
