### PR TITLE
Fix TypeError crash on Machine Pools tab for nodes without a pool assignment

### DIFF
--- a/shell/models/__tests__/management.cattle.io.node.ts
+++ b/shell/models/__tests__/management.cattle.io.node.ts
@@ -94,6 +94,28 @@ describe('class MgmtNode', () => {
     });
   });
 
+  describe('pool', () => {
+    it('should return undefined if nodePoolName is not set', () => {
+      const mgmtNode = new MgmtNode({ spec: {} });
+
+      expect(mgmtNode.pool).toBeUndefined();
+    });
+
+    it('should return the node pool when nodePoolName is set', () => {
+      const nodePool = { id: 'fleet-local/np1' };
+      const mgmtNodeCtx = {
+        rootGetters: {
+          'i18n/t':          t,
+          'management/byId': jest.fn(() => nodePool)
+        }
+      };
+      const mgmtNode = new MgmtNode({ spec: { nodePoolName: 'fleet-local:np1' } }, mgmtNodeCtx);
+
+      expect(mgmtNode.pool).toStrictEqual(nodePool);
+      expect(mgmtNodeCtx.rootGetters['management/byId']).toHaveBeenCalledWith('management.cattle.io.nodepool', 'fleet-local/np1');
+    });
+  });
+
   describe('canScaleDown', () => {
     const mgmtClusterId = 'test';
     const nodeId = 'test/id';

--- a/shell/models/management.cattle.io.node.js
+++ b/shell/models/management.cattle.io.node.js
@@ -64,6 +64,10 @@ export default class MgmtNode extends HybridModel {
   }
 
   get pool() {
+    if (!this.spec?.nodePoolName) {
+      return undefined;
+    }
+
     const nodePoolID = this.spec.nodePoolName.replace(':', '/');
 
     return this.$rootGetters['management/byId'](MANAGEMENT.NODE_POOL, nodePoolID);


### PR DESCRIPTION
Replicated PR for QA-workflow testing (base `master-test`).

Fixes #397
