### PR TITLE
Remove `toRef()` when setting the namespace value with `forceNamespace`

### DIFF
--- a/shell/components/form/NameNsDescription.vue
+++ b/shell/components/form/NameNsDescription.vue
@@ -310,8 +310,8 @@ export default {
 
     if (props.namespaced) {
       if (props.forceNamespace) {
-        namespace.value = toRef(props.forceNamespace);
-        updateNamespace(namespace);
+        namespace.value = props.forceNamespace;
+        updateNamespace(namespace.value);
       } else if (props.namespaceKey) {
         namespace.value = get(v.value, props.namespaceKey);
       } else {
@@ -321,7 +321,7 @@ export default {
       if (!namespace.value && !props.noDefaultNamespace) {
         namespace.value = store.getters['defaultNamespace'];
         if (metadata) {
-          metadata.namespace = namespace;
+          metadata.namespace = namespace.value;
         }
       }
     }

--- a/shell/components/form/__tests__/NameNsDescription.test.ts
+++ b/shell/components/form/__tests__/NameNsDescription.test.ts
@@ -170,6 +170,81 @@ describe('component: NameNsDescription', () => {
     expect(nameInput.element.value).toBe('Default');
   });
 
+  it('should set namespace to a plain string when forceNamespace prop is provided', () => {
+    const forcedNs = 'cert-manager';
+    const store = createStore({
+      getters: {
+        allowedNamespaces:   () => () => ({}),
+        currentStore:        () => () => 'cluster',
+        'cluster/schemaFor': () => jest.fn()
+      }
+    });
+
+    const wrapper = mount(NameNsDescription, {
+      props: {
+        value: {
+          setAnnotation: jest.fn(),
+          metadata:      { namespace: '' }
+        },
+        mode:           'create',
+        forceNamespace: forcedNs,
+      },
+      global: {
+        provide: { store },
+        mocks:   {
+          $store: {
+            dispatch: jest.fn(),
+            getters:  {
+              namespaces: jest.fn(),
+              'i18n/t':   jest.fn(),
+            },
+          },
+        },
+      },
+    });
+
+    expect(typeof (wrapper.vm as any).namespace).toBe('string');
+    expect((wrapper.vm as any).namespace).toBe(forcedNs);
+  });
+
+  it('should set metadata.namespace to a plain string when falling back to defaultNamespace', () => {
+    const defaultNs = 'default';
+    const metadata: Record<string, unknown> = {};
+    const store = createStore({
+      getters: {
+        allowedNamespaces:   () => () => ({}),
+        currentStore:        () => () => 'cluster',
+        'cluster/schemaFor': () => jest.fn(),
+        defaultNamespace:    () => defaultNs,
+      }
+    });
+
+    mount(NameNsDescription, {
+      props: {
+        value: {
+          setAnnotation: jest.fn(),
+          metadata,
+        },
+        mode: 'create',
+      },
+      global: {
+        provide: { store },
+        mocks:   {
+          $store: {
+            dispatch: jest.fn(),
+            getters:  {
+              namespaces: jest.fn(),
+              'i18n/t':   jest.fn(),
+            },
+          },
+        },
+      },
+    });
+
+    expect(typeof metadata.namespace).toBe('string');
+    expect(metadata.namespace).toBe(defaultNs);
+  });
+
   it('sets the name using the nameKey prop', () => {
     const namespaceName = 'test';
     const store = createStore({


### PR DESCRIPTION
Replicated PR for QA-workflow testing (base `master-test`).

Fixes #403
