### PR TITLE
Disabled editing capi clusters as yaml from editing as config

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
+++ b/shell/edit/provisioning.cattle.io.cluster/__tests__/rke2.test.ts
@@ -806,4 +806,22 @@ describe('component: rke2', () => {
       expect(wrapper.vm.value.spec.rkeConfig.machineGlobalConfig[INGRESS_CONTROLLER]).toBe(INGRESS_NGINX);
     });
   });
+
+  describe('computed: canEditAsYaml', () => {
+    it('should return false when isUpstreamCAPIProvider is true', () => {
+      const vm = { isUpstreamCAPIProvider: true } as any;
+
+      const canEditAsYaml = rke2.computed!.canEditAsYaml.call(vm);
+
+      expect(canEditAsYaml).toBe(false);
+    });
+
+    it('should return true when isUpstreamCAPIProvider is false', () => {
+      const vm = { isUpstreamCAPIProvider: false } as any;
+
+      const canEditAsYaml = rke2.computed!.canEditAsYaml.call(vm);
+
+      expect(canEditAsYaml).toBe(true);
+    });
+  });
 });

--- a/shell/edit/provisioning.cattle.io.cluster/rke2.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/rke2.vue
@@ -903,6 +903,10 @@ export default {
       return this.needCredential && !this.credentialId;
     },
 
+    canEditAsYaml() {
+      return !(this.isUpstreamCAPIProvider);
+    },
+
     overallFormValidationPassed() {
       return this.validationPassed &&
             this.fvFormIsValid &&
@@ -2401,6 +2405,7 @@ export default {
     :done-route="doneRoute"
     :apply-hooks="applyHooks"
     :generate-yaml="generateYaml"
+    :can-yaml="canEditAsYaml"
     class="rke2"
     component-testid="rke2-custom-create"
     @done="done"


### PR DESCRIPTION
Replicated PR for QA-workflow testing (base `master-test`).

Fixes #419
