### PR TITLE
Fix three bugs that can result in an empty cluster list after returning from edit

### DIFF
--- a/shell/edit/provisioning.cattle.io.cluster/index.vue
+++ b/shell/edit/provisioning.cattle.io.cluster/index.vue
@@ -87,7 +87,7 @@ export default {
       await this.$store.dispatch('management/watch', { type: MANAGEMENT.CLUSTER, registerType: true });
       await this.$store.dispatch('management/watch', { type: CAPI.RANCHER_CLUSTER, registerType: true });
     } else {
-      hash.mgmtClusters = this.value.waitForMgmt();
+      hash.mgmtCluster = this.value.waitForMgmt();
     }
 
     // No need to fetch charts when editing an RKE1 cluster

--- a/shell/mixins/resource-fetch.js
+++ b/shell/mixins/resource-fetch.js
@@ -35,7 +35,7 @@ export default {
     // Normally owner components supply `resource` and `inStore` as part of their data, however these are needed here before parent data runs
     // So set up both here
     const params = { ...this.$route.params };
-    const resource = params.resource || this.schema?.id; // Resource can either be on a page showing single list, or a page of a resource showing a list of another resource
+    const resource = this.schema?.id || params.resource; // Resource can either be on a page showing single list, or a page of a resource showing a list of another resource
     const inStore = this.$store.getters['currentStore'](resource);
 
     return {

--- a/shell/plugins/steve/subscribe.js
+++ b/shell/plugins/steve/subscribe.js
@@ -834,6 +834,17 @@ const defaultActions = {
     state.debugSocket && console.debug(`Subscribe Flush [${ getters.storeName }]`, queue.length, 'items'); // eslint-disable-line no-console
 
     for ( const { action, event, body } of queue ) {
+      const havePage = getters['havePage'](body?.type);
+
+      if (havePage) {
+        // eslint-disable-next-line no-console
+        console.warn(`Prevented watch \`flush\` data from polluting the cache for type "${ body?.type }" (currently represents a page)`, {
+          action, event, body
+        });
+
+        continue;
+      }
+
       if ( action === 'dispatch' && event === 'load' ) {
         // Group loads into one loadMulti when possible
         toLoad.push(body);

--- a/shell/utils/async.ts
+++ b/shell/utils/async.ts
@@ -5,6 +5,8 @@ export const waitFor = (testFn: Function, msg = '', timeoutMs = 3000000, interva
     if (testFn()) {
       gatedLog('Wait for', msg || 'unknown', 'done immediately');
       resolve(this);
+
+      return;
     }
     const timeout = setTimeout(() => {
       gatedLog('Wait for', msg, 'timed out');


### PR DESCRIPTION
Replicated PR for QA-workflow testing (base `master-test`).

Fixes #423
