### PR TITLE
add support for node driver multiline hint annotation, and password-type cloud credential fields

### DIFF
--- a/shell/cloud-credential/__tests__/generic.test.ts
+++ b/shell/cloud-credential/__tests__/generic.test.ts
@@ -1,0 +1,132 @@
+import { shallowMount } from '@vue/test-utils';
+import Generic, { INPUT_TYPES } from '@shell/cloud-credential/generic.vue';
+import { SCHEMA } from '@shell/config/types';
+
+const DRIVER_NAME = 'testdriver';
+const CONFIG_ID = `testdrivercredentialconfig`;
+
+/**
+ * Build a normanSchema whose resourceFields include one field per INPUT_TYPE
+ * plus a plain "string" field (which should fall back to "text").
+ */
+const buildResourceFields = () => {
+  const fields: Record<string, { type: string }> = {};
+
+  INPUT_TYPES.forEach((t) => {
+    fields[`${ t }Field`] = { type: t };
+  });
+  fields.stringField = { type: 'string' };
+
+  return fields;
+};
+
+const normanSchema = { resourceFields: buildResourceFields() };
+
+const mockedStore = () => ({
+  getters: {
+    'i18n/t':                           (key: string) => key,
+    t:                                  (key: string) => key,
+    'plugins/credentialFieldForDriver': () => DRIVER_NAME,
+    'plugins/fieldNamesForDriver':      () => [],
+  },
+  dispatch: jest.fn((_action: string, args: any) => {
+    if (args?.type === SCHEMA && args?.id === CONFIG_ID) {
+      return Promise.resolve(normanSchema);
+    }
+
+    return Promise.resolve(null);
+  }),
+});
+
+const mountGeneric = () => {
+  const store = mockedStore();
+  const value = {
+    decodedData: {} as Record<string, string>,
+    setData:     jest.fn(),
+  };
+
+  return shallowMount(Generic, {
+    props: {
+      driverName: DRIVER_NAME,
+      value,
+      mode:       'edit',
+    },
+    global: {
+      mocks: {
+        $store:      store,
+        $fetchState: { pending: false },
+      },
+    },
+    data() {
+      return {
+        normanSchema,
+        keyOptions: Object.keys(normanSchema.resourceFields),
+      } as any;
+    },
+  });
+};
+
+describe('generic cloud credential', () => {
+  describe('typeForField', () => {
+    it.each(INPUT_TYPES)('should return "%s" for a field with type "%s"', (inputType) => {
+      const wrapper = mountGeneric();
+
+      expect((wrapper.vm as any).typeForField(`${ inputType }Field`)).toBe(inputType);
+    });
+
+    it('should fall back to "text" for a field type not in INPUT_TYPES', () => {
+      const wrapper = mountGeneric();
+
+      expect((wrapper.vm as any).typeForField('stringField')).toBe('text');
+    });
+
+    it('should fall back to "text" when no normanSchema could be located', () => {
+      const store = {
+        ...mockedStore(),
+        dispatch: jest.fn(() => Promise.resolve(null)),
+      };
+
+      const wrapper = shallowMount(Generic, {
+        props: {
+          driverName: DRIVER_NAME,
+          value:      { decodedData: {}, setData: jest.fn() },
+          mode:       'edit',
+        },
+        global: {
+          mocks: {
+            $store:      store,
+            $fetchState: { pending: false },
+          },
+        },
+        data() {
+          return { normanSchema: null, keyOptions: [] };
+        },
+      });
+
+      expect((wrapper.vm as any).typeForField('passwordField')).toBe('text');
+      expect((wrapper.vm as any).typeForField('cronField')).toBe('text');
+      expect((wrapper.vm as any).typeForField('anyField')).toBe('text');
+    });
+  });
+
+  describe('LabeledInput rendering', () => {
+    it('should render a LabeledInput inside the KeyValue value slot', () => {
+      const wrapper = mountGeneric();
+      const keyValue = wrapper.findComponent({ name: 'KeyValue' });
+
+      expect(keyValue.exists()).toBe(true);
+
+      // The component registers LabeledInput and passes typeForField via the slot template
+      expect((wrapper.vm as any).$options.components.LabeledInput).toBeDefined();
+    });
+
+    it('should pass typeForField result as the type prop to LabeledInput', () => {
+      const wrapper = mountGeneric();
+
+      // Validate the integration: typeForField returns the correct type for each INPUT_TYPE field
+      INPUT_TYPES.forEach((inputType) => {
+        expect((wrapper.vm as any).typeForField(`${ inputType }Field`)).toBe(inputType);
+      });
+    });
+  });
+});

--- a/shell/cloud-credential/generic.vue
+++ b/shell/cloud-credential/generic.vue
@@ -5,13 +5,24 @@ import { Banner } from '@components/Banner';
 import { simplify, iffyFields, likelyFields } from '@shell/store/plugins';
 import Loading from '@shell/components/Loading';
 import { SCHEMA } from '@shell/config/types';
+import { LabeledInput } from '@components/Form/LabeledInput';
+
+export const INPUT_TYPES = [
+  'number',
+  'password',
+  'text',
+];
 
 export default {
   emits: ['validationChanged'],
 
   components: {
-    KeyValue, Banner, Loading
+    KeyValue,
+    Banner,
+    Loading,
+    LabeledInput
   },
+
   mixins: [CreateEditView],
 
   props: {
@@ -60,6 +71,7 @@ export default {
     return {
       errors:       null,
       normanSchema: null,
+      keyOptions:   [],
     };
   },
 
@@ -72,7 +84,14 @@ export default {
   methods: {
     update(val) {
       this.value.setData(val);
-    }
+    },
+
+    typeForField(fieldName = '') {
+      const fieldSchema = this.normanSchema?.resourceFields?.[fieldName] || {};
+      const fieldType = fieldSchema.type || '';
+
+      return INPUT_TYPES.includes(fieldType) ? fieldType : 'text';
+    },
   },
 
   computed: {
@@ -103,6 +122,17 @@ export default {
       :remove-allowed="!hasSupport"
       :initial-empty-row="true"
       @update:value="update"
-    />
+    >
+      <template #value="{row, mode, queueUpdate}">
+        <LabeledInput
+          v-model:value="row.value"
+          :mode="mode"
+          :type="typeForField(row.key)"
+          :aria-label="row.key || t('generic.value')"
+          placeholder-key="keyValue.valuePlaceholder"
+          @update:value="queueUpdate"
+        />
+      </template>
+    </KeyValue>
   </div>
 </template>

--- a/shell/config/labels-annotations.js
+++ b/shell/config/labels-annotations.js
@@ -20,6 +20,7 @@ export const IMPORTED_CLUSTER_VERSION_MANAGEMENT = 'rancher.io/imported-cluster-
 export const UI_PROJECT_SECRET = 'management.cattle.io/project-scoped-secret';
 export const UI_PROJECT_SECRET_COPY = 'management.cattle.io/project-scoped-secret-copy';
 export const SERVICE_LINKS = 'ui.rancher/service-links';
+export const NODE_DRIVER_FIELD_HINTS = 'io.cattle.nodedriver/ui-field-hints';
 
 export const KUBERNETES = {
   SERVICE_ACCOUNT_UID:  'kubernetes.io/service-account.uid',

--- a/shell/machine-config/__tests__/generic.test.ts
+++ b/shell/machine-config/__tests__/generic.test.ts
@@ -1,0 +1,163 @@
+import Generic from '@shell/machine-config/generic.vue';
+import { shallowMount } from '@vue/test-utils';
+import { MANAGEMENT } from '@shell/config/types';
+import { NODE_DRIVER_FIELD_HINTS } from '@shell/config/labels-annotations';
+import { Banner } from '@components/Banner';
+import Questions from '@shell/components/Questions';
+
+const PROVIDER = 'testdriver';
+
+const buildFields = () => ({
+  zone:       { type: 'string' },
+  diskSize:   { type: 'string' },
+  enginePort: { type: 'string' },
+});
+
+const mockedStore = (fieldHints: Record<string, { type: string }> | null = null) => {
+  const driver = { metadata: { annotations: { ...(fieldHints ? { [NODE_DRIVER_FIELD_HINTS]: JSON.stringify(fieldHints) } : {}) } } };
+
+  return {
+    getters: {
+      'i18n/t':                           (key: string) => key,
+      t:                                  (key: string) => key,
+      'plugins/fieldsForDriver':          () => Promise.resolve(buildFields()),
+      'plugins/credentialFieldForDriver': () => PROVIDER,
+      'plugins/fieldNamesForDriver':      () => [],
+      'rancher/schemaFor':                () => null,
+    },
+    dispatch: jest.fn((_action: string, args: any) => {
+      if (args?.type === MANAGEMENT.NODE_DRIVER && args?.id === PROVIDER) {
+        return Promise.resolve(driver);
+      }
+
+      return Promise.resolve(null);
+    }),
+  };
+};
+
+const mountAndFetch = async(storeOverrides: Record<string, any> = {}) => {
+  const store = {
+    ...mockedStore(null),
+    ...storeOverrides,
+    getters: {
+      ...mockedStore(null).getters,
+      ...(storeOverrides.getters || {}),
+    },
+  };
+
+  if (storeOverrides.dispatch) {
+    store.dispatch = storeOverrides.dispatch;
+  }
+
+  const wrapper = shallowMount(Generic, {
+    props: {
+      credentialId: 'cattle-global-data:cc-12345',
+      provider:     PROVIDER,
+      value:        { metadata: { namespace: 'fleet-default' } },
+      mode:         'edit',
+    },
+    global: {
+      mocks: {
+        $store:      store,
+        $fetchState: { pending: false },
+      },
+    },
+  });
+
+  await (Generic as any).fetch.call(wrapper.vm);
+  await wrapper.vm.$nextTick();
+
+  return wrapper;
+};
+
+describe('generic machine config', () => {
+  describe('io.cattle.nodedriver/ui-field-hints annotation', () => {
+    it('should override field types when type hints are provided', async() => {
+      const hints = {
+        zone:     { type: 'multiline' },
+        diskSize: { type: 'multiline' },
+      };
+      const wrapper = await mountAndFetch({
+        ...mockedStore(hints),
+        getters: { ...mockedStore(hints).getters },
+      });
+
+      expect((wrapper.vm as any).fields.zone.type).toBe('multiline');
+      expect((wrapper.vm as any).fields.diskSize.type).toBe('multiline');
+    });
+
+    it('should not modify fields that are not in the hints', async() => {
+      const hints = { zone: { type: 'multiline' } };
+      const wrapper = await mountAndFetch({
+        ...mockedStore(hints),
+        getters: { ...mockedStore(hints).getters },
+      });
+
+      expect((wrapper.vm as any).fields.enginePort.type).toBe('string');
+    });
+
+    it('should not modify fields when no hints annotation exists', async() => {
+      const wrapper = await mountAndFetch();
+
+      expect((wrapper.vm as any).fields.zone.type).toBe('string');
+      expect((wrapper.vm as any).fields.diskSize.type).toBe('string');
+      expect((wrapper.vm as any).fields.enginePort.type).toBe('string');
+    });
+
+    it('should ignore hint entries for fields not present in the schema', async() => {
+      const hints = { nonExistentField: { type: 'multiline' } };
+      const wrapper = await mountAndFetch({
+        ...mockedStore(hints),
+        getters: { ...mockedStore(hints).getters },
+      });
+
+      expect((wrapper.vm as any).fields.zone.type).toBe('string');
+      expect((wrapper.vm as any).fields.nonExistentField).toBeUndefined();
+    });
+
+    it('should ignore hint entries that do not specify a type', async() => {
+      const hints = { zone: { otherKey: 'blah' } } as any;
+      const wrapper = await mountAndFetch({
+        ...mockedStore(hints),
+        getters: { ...mockedStore(hints).getters },
+      });
+
+      expect((wrapper.vm as any).fields.zone.type).toBe('string');
+    });
+
+    it('should handle malformed JSON in the annotation gracefully', async() => {
+      const driver = { metadata: { annotations: { [NODE_DRIVER_FIELD_HINTS]: 'testing bad json{' } } };
+      const wrapper = await mountAndFetch({ dispatch: jest.fn(() => Promise.resolve(driver)) });
+
+      expect((wrapper.vm as any).fields.zone.type).toBe('string');
+      expect((wrapper.vm as any).errors.length).toBe(1);
+    });
+  });
+
+  describe('data fetching failures', () => {
+    it('should render an error banner and not render Questions when unable to determine fields for the driver', async() => {
+      const wrapper = await mountAndFetch({ getters: { 'plugins/fieldsForDriver': () => Promise.resolve(null) } });
+
+      expect((wrapper.vm as any).errors.length).toBe(1);
+      expect((wrapper.vm as any).errors[0].message).toContain(`Machine Driver config schema not found for rke-machine-config.cattle.io.${ PROVIDER }config`);
+
+      const banners = wrapper.findAllComponents(Banner);
+
+      expect(banners.length).toBe(1);
+      expect(wrapper.findComponent(Questions).exists()).toBe(false);
+    });
+
+    it('should render an error banner but still render Questions when unable to retrieve node driver field hints', async() => {
+      const driverError = 'node driver not found';
+      const wrapper = await mountAndFetch({ dispatch: jest.fn(() => Promise.reject(new Error(driverError))) });
+
+      expect((wrapper.vm as any).errors.length).toBe(1);
+      expect((wrapper.vm as any).errors[0].message).toContain(driverError);
+
+      const banners = wrapper.findAllComponents(Banner);
+
+      expect(banners.length).toBe(1);
+      expect(wrapper.findComponent(Questions).exists()).toBe(true);
+    });
+  });
+});

--- a/shell/machine-config/generic.vue
+++ b/shell/machine-config/generic.vue
@@ -4,6 +4,10 @@ import { Banner } from '@components/Banner';
 import CreateEditView from '@shell/mixins/create-edit-view';
 import { exceptionToErrorsArray, stringify } from '@shell/utils/error';
 import Questions from '@shell/components/Questions';
+import { MANAGEMENT } from '@shell/config/types';
+import { NODE_DRIVER_FIELD_HINTS } from '@shell/config/labels-annotations';
+import { isEmpty } from '@shell/utils/object';
+import cloneDeep from 'lodash/cloneDeep';
 
 export default {
   emits: ['input'],
@@ -35,11 +39,35 @@ export default {
     this.errors = [];
 
     try {
-      this.fields = await this.$store.getters['plugins/fieldsForDriver'](this.provider);
+      const fields = await this.$store.getters['plugins/fieldsForDriver'](this.provider);
+
+      // copy the result of the getter before modifying it to add hints
+      this.fields = cloneDeep(fields);
       const name = `rke-machine-config.cattle.io.${ this.provider }config`;
 
       if ( !this.fields ) {
         throw new Error(`Machine Driver config schema not found for ${ name }`);
+      }
+    } catch (e) {
+      this.errors = exceptionToErrorsArray(e);
+
+      return;
+    }
+
+    try {
+      const driver = await this.$store.dispatch('management/find', { type: MANAGEMENT.NODE_DRIVER, id: this.provider } );
+      const fieldHints = driver?.metadata?.annotations?.[NODE_DRIVER_FIELD_HINTS];
+      let parsedHints;
+
+      if (fieldHints) {
+        parsedHints = JSON.parse(fieldHints);
+      }
+      if (parsedHints && !isEmpty(parsedHints)) {
+        Object.keys(this.fields).forEach((fieldKey) => {
+          if (parsedHints[fieldKey] && parsedHints[fieldKey].type) {
+            this.fields[fieldKey].type = parsedHints[fieldKey].type;
+          }
+        });
       }
     } catch (e) {
       this.errors = exceptionToErrorsArray(e);
@@ -77,7 +105,7 @@ export default {
     v-if="$fetchState.pending"
     :delayed="true"
   />
-  <div v-else-if="errors.length">
+  <template v-else>
     <div
       v-for="(err, idx) in errors"
       :key="idx"
@@ -87,9 +115,8 @@ export default {
         :label="stringify(err)"
       />
     </div>
-  </div>
-  <div v-else>
     <Questions
+      v-if="fields"
       :value="value"
       :mode="mode"
       :tabbed="false"
@@ -99,5 +126,5 @@ export default {
       :disabled="disabled"
       @update:value="$emit('input', $event)"
     />
-  </div>
+  </template>
 </template>


### PR DESCRIPTION
Replicated PR for QA-workflow testing (base `master-test`).

Fixes #435
