### PR TITLE
fix aks and gke pool weight so pools dont change order when re-named

### DIFF
--- a/pkg/aks/components/Config.vue
+++ b/pkg/aks/components/Config.vue
@@ -899,7 +899,7 @@ export default defineComponent({
         <Tab
           v-for="(pool, i) in nodePools"
           :key="i"
-          :weight="-1 * idx"
+          :weight="-1 * i"
           :name="pool._id || pool.name"
           :label="pool.name || t('aks.nodePools.notNamed')"
           :error="!poolIsValid(pool)"

--- a/pkg/gke/components/CruGKE.vue
+++ b/pkg/gke/components/CruGKE.vue
@@ -808,7 +808,7 @@ export default defineComponent({
           @removeTab="removePool($event)"
         >
           <Tab
-            v-for="(pool) in nodePools"
+            v-for="(pool, idx) in nodePools"
             :key="pool._id"
             :weight="-1 * idx"
             :name="pool._id || pool.name"


### PR DESCRIPTION
Replicated PR for QA-workflow testing (base `master-test`).

Fixes #437
