### PR TITLE
test: auto-retry sandbox (do not merge)

### DIFF
--- a/AUTO_RETRY_TEST_SANDBOX.md
+++ b/AUTO_RETRY_TEST_SANDBOX.md
@@ -1,0 +1,5 @@
+# Auto-Retry Test Sandbox
+
+Throwaway PR to test the auto-retry workflow (retry + PR comment behaviour) on the fork.
+
+**Do not merge.**


### PR DESCRIPTION
Throwaway PR to exercise the auto-retry workflow on the fork (retry + PR comment behaviour).

- No `bot/auto-retry/N` label => default path: single retry on first Tests failure + PR comment.
- Add `bot/auto-retry/10` to switch to the label path (up to 10 retries, no comment).

Do not merge.